### PR TITLE
use bytearray instead of bytes for compatibility with Py2

### DIFF
--- a/idzip/compressor.py
+++ b/idzip/compressor.py
@@ -137,7 +137,7 @@ def _prepare_header(output, in_size, basename, mtime):
     flags = FEXTRA
     if basename:
         flags |= FNAME
-    output.write(bytes([flags]))
+    output.write(bytearray([flags]))
 
     # The mtime will be undefined if it does not fit.
     if mtime > 0xffffffff:
@@ -148,7 +148,7 @@ def _prepare_header(output, in_size, basename, mtime):
     if COMPRESSION_LEVEL == zlib.Z_BEST_COMPRESSION:
         deflate_flags = b"\x02"  # slowest compression algorithm
     output.write(deflate_flags)
-    output.write(bytes([OS_CODE_UNIX]))
+    output.write(bytearray([OS_CODE_UNIX]))
 
     zlengths_pos = _write_extra_field(output, in_size)
     if basename:


### PR DESCRIPTION
In Python 3, `bytes([12])` and `bytearray([12])` translates to the same binary representation, `"\x0c"`, while in Python 2, `bytes([12])` is the same as `str([12])`, which is `"[12]"`, but `bytearray([12])` still returns the same construct as in Python 3.

Is there any interest in putting this on the Python Package Index so other libraries can depend upon it?