### PR TITLE
add executable entry point to setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,10 @@ from setuptools import setup, find_packages
 setup(
     name = "python-idzip",
     version = "0.1",
-    packages=find_packages()
+    packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "idzip = idzip.command:main"
+        ]
+    }
 )


### PR DESCRIPTION
Added an executable entry point called `idzip` so that the program can be invoked without writing `python -m idzip.command` but otherwise identical.

