### PR TITLE
Increase Compatibility with Standard Library gzip.GzipFile

### DIFF
--- a/idzip/__init__.py
+++ b/idzip/__init__.py
@@ -1,7 +1,7 @@
 from idzip.compressor import MAX_MEMBER_SIZE, compress_member
 from idzip.api import (
-    IdZipFile, compress, decompress, open as dzopen,
-    IdZipWriter as Writer)
+    IdzipFile, compress, decompress, open as dzopen,
+    IdzipWriter as Writer)
 
 # get a copy of the open standard file open before overwriting
 fopen = open
@@ -10,6 +10,6 @@ open = dzopen
 
 __all__ = [
     "MAX_MEMBER_SIZE", "compress_member",
-    "IdZipFile", "compress", "decompress",
+    "IdzipFile", "compress", "decompress",
     "Writer", "open"
 ]

--- a/idzip/__init__.py
+++ b/idzip/__init__.py
@@ -1,57 +1,15 @@
 from idzip.compressor import MAX_MEMBER_SIZE, compress_member
-from io import BytesIO
-from os import path, SEEK_END
+from idzip.api import (
+    IdZipFile, compress, decompress, open as dzopen,
+    IdZipWriter as Writer)
 
-#get a copy of the open standard file open before overwriting
+# get a copy of the open standard file open before overwriting
 fopen = open
+open = dzopen
 
-def open(filename):
-    from idzip.decompressor import IdzipFile
-    try:
-        return IdzipFile(filename)
-    except IOError as e:
-        import logging
-        import gzip
-        logging.info("Using gzip fallback: %r", e)
-        return gzip.open(filename, "rb")
 
-class Writer(object):
-    def __init__(self, output, sync_size=MAX_MEMBER_SIZE):
-        if isinstance(output, basestring):
-            self.output = fopen(output, "wb")
-        else:
-            self.output = output #hopefully a file like object
-            self.output.seek(0) #throw exception now if this isnt a file like obj
-        self.input_buffer = BytesIO()
-        self.basename = path.basename(path.abspath(self.output.name))
-        self.pos = 0
-        self.sync_size = sync_size
-
-    def write(self, str_buffer):
-        start_pos = self.pos
-        self.input_buffer.write(str_buffer)
-        self.pos += len(str_buffer)
-        curpos = self.input_buffer.tell()
-        self.input_buffer.seek(0, SEEK_END)
-        buffer_len = self.input_buffer.tell()
-        self.input_buffer.seek(curpos)
-        if buffer_len > self.sync_size:
-            self.sync()
-            self.input_buffer = BytesIO()
-        return start_pos, len(str_buffer)
-
-    def sync(self):
-        self.input_buffer.seek(0, SEEK_END)
-        member_size = self.input_buffer.tell()
-        self.input_buffer.seek(0)
-        compress_member(self.input_buffer, member_size, self.output, self.basename, 0)
-        self.input_buffer.truncate(0)
-        return self.output.tell()
-
-    def tell(self):
-        return self.pos
-
-    def close(self):
-        self.sync()
-        return self.output.close()
-
+__all__ = [
+    "MAX_MEMBER_SIZE", "compress_member",
+    "IdZipFile", "compress", "decompress",
+    "Writer", "open"
+]

--- a/idzip/_stream.py
+++ b/idzip/_stream.py
@@ -1,6 +1,6 @@
 
 
-class _CompressedStreamWrapperMixin(object):
+class IOStreamWrapperMixin(object):
 
     @property
     def closed(self):
@@ -14,3 +14,7 @@ class _CompressedStreamWrapperMixin(object):
 
     def writable(self):
         return self.stream.writable()
+
+    def __del__(self):
+        if not self.closed:
+            self.close()

--- a/idzip/_stream.py
+++ b/idzip/_stream.py
@@ -15,6 +15,16 @@ class IOStreamWrapperMixin(object):
     def writable(self):
         return self.stream.writable()
 
+    def fileno(self):
+        return self.stream.fileno()
+
     def __del__(self):
         if not self.closed:
             self.close()
+
+
+def check_file_like_for_writing(f):
+    check = (
+        hasattr(f, "write") and hasattr(f, "tell") and
+        hasattr(f, 'flush') and hasattr(f, 'close)'))
+    return check

--- a/idzip/_stream.py
+++ b/idzip/_stream.py
@@ -1,0 +1,16 @@
+
+
+class _CompressedStreamWrapperMixin(object):
+
+    @property
+    def closed(self):
+        return self.stream.closed
+
+    def seekable(self):
+        return self.stream.seekable()
+
+    def readable(self):
+        return self.stream.readable()
+
+    def writable(self):
+        return self.stream.writable()

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -23,7 +23,7 @@ def decompress(data):
 
 
 class IdzipFile(object):
-    def __init__(self, filename=None, mode="rb", fileobj=None, sync_size=MAX_MEMBER_SIZE):
+    def __init__(self, filename=None, mode="rb", fileobj=None, sync_size=MAX_MEMBER_SIZE, mtime=None):
         self._impl = None
         if 'b' not in mode:
             mode += 'b'
@@ -36,9 +36,9 @@ class IdzipFile(object):
             if filename is None:
                 if fileobj is None:
                     raise ValueError("Must provide a filename or a fileobj argument")
-                self._impl = self._make_writer(fileobj, sync_size=sync_size)
+                self._impl = self._make_writer(fileobj, sync_size=sync_size, mtime=mtime)
             else:
-                self._impl = self._make_writer(filename, sync_size=sync_size)
+                self._impl = self._make_writer(filename, sync_size=sync_size, mtime=mtime)
         else:
             raise IOError("Unsupported mode %r" % mode)
         self.mode = mode
@@ -49,8 +49,8 @@ class IdzipFile(object):
     def _fallback_to_gzip(self, filename, mode, fileobj):
         return GzipFile(filename, mode=mode, fileobj=fileobj)
 
-    def _make_writer(self, filespec, sync_size):
-        return IdzipWriter(filespec, sync_size=sync_size)
+    def _make_writer(self, filespec, sync_size, mtime):
+        return IdzipWriter(filespec, sync_size=sync_size, mtime=mtime)
 
     @property
     def name(self):

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -1,0 +1,117 @@
+import io
+import os
+import errno
+
+from idzip.compressor import IdzipWriter, MAX_MEMBER_SIZE
+from idzip.decompressor import IdzipReader
+from gzip import GzipFile
+
+
+def open(filename, mode='rb', sync_size=MAX_MEMBER_SIZE):
+    return IdZipFile(filename, mode, sync_size=MAX_MEMBER_SIZE)
+
+
+def compress(data, sync_size=MAX_MEMBER_SIZE):
+    out = io.BytesIO()
+    writer = IdZipFile(mode='w', fileobj=out, sync_size=sync_size)
+    writer.write(data)
+    return out.getvalue()
+
+
+def decompress(data):
+    in_ = io.BytesIO(data)
+    return IdZipFile(fileobj=in_).read()
+
+
+class IdzipFile(object):
+    def __init__(self, filename=None, mode="rb", fileobj=None, sync_size=MAX_MEMBER_SIZE):
+        self._impl = None
+        if 'b' not in mode:
+            mode += 'b'
+        if "r" in mode:
+            try:
+                self._impl = self._make_reader(filename, mode, fileobj)
+            except IOError:
+                self._impl = self._fallback_to_gzip(filename, mode, fileobj)
+        elif 'w' in mode:
+            if filename is None:
+                if fileobj is None:
+                    raise ValueError("Must provide a filename or a fileobj argument")
+                self._impl = self._make_writer(fileobj, sync_size=sync_size)
+            else:
+                self._impl = self._make_writer(filename, sync_size=sync_size)
+        else:
+            raise IOError("Unsupported mode %r" % mode)
+        self.mode = mode
+
+    def _make_reader(self, filename, mode, fileobj):
+        return IdzipReader(filename, fileobj=fileobj)
+
+    def _fallback_to_gzip(self, filename, mode, fileobj):
+        return GzipFile(filename, mode=mode, fileobj=fileobj)
+
+    def _make_writer(self, filespec, sync_size):
+        return IdZipWriter(filespec, sync_size=sync_size)
+
+    @property
+    def name(self):
+        return self._impl.name
+
+    def close(self):
+        return self._impl.close()
+
+    def flush(self):
+        return self._impl.flush()
+
+    def write(self, b):
+        if "r" in self.mode:
+            raise OSError(errno.EBADF, "Cannot write to a read-only file")
+        self._impl.write(b)
+
+    def read(self, size=-1):
+        if "r" not in self.mode:
+            raise OSError(errno.EBADF, "Cannot read from a write-only file")
+        return self._impl.read(size)
+
+    def _check_can_read(self):
+        if "r" not in self.mode:
+            raise OSError(errno.EBADF, "Cannot read from a write-only file")
+        if self.closed():
+            raise OSError(errno.EBADF, "Cannot read from a closed file")
+
+    def _check_can_write(self):
+        if not (set("wax") & set(self.mode)):
+            raise OSError(errno.EBADF, "Cannot write to a read-only file")
+        if self.closed():
+            raise OSError(errno.EBADF, "Cannot write to a closed file")
+
+    def readable(self):
+        return self._impl.stream.readable()
+
+    def writable(self):
+        return self._impl.stream.writable()
+
+    def closed(self):
+        return self._impl.stream.closed()
+
+    def seekable(self):
+        return self._impl.stream.seekable()
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        return self._impl.seek(offset, whence)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def readline(self, size=-1):
+        self._check_can_read()
+        return self._impl.readline()
+
+    def __iter__(self):
+        line = self.readline()
+        while line:
+            yield line
+            line = self.readline()

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -113,3 +113,9 @@ class IdzipFile(object):
         while line:
             yield line
             line = self.readline()
+
+    def __repr__(self):
+        return "<idzip %s file %r at %s>" % (
+            "open" if not self.closed else "closed",
+            self.name,
+            hex(id(self)))

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -1,5 +1,4 @@
 import io
-import os
 import errno
 
 from idzip.compressor import IdzipWriter, MAX_MEMBER_SIZE
@@ -8,19 +7,19 @@ from gzip import GzipFile
 
 
 def open(filename, mode='rb', sync_size=MAX_MEMBER_SIZE):
-    return IdZipFile(filename, mode, sync_size=MAX_MEMBER_SIZE)
+    return IdzipFile(filename, mode, sync_size=MAX_MEMBER_SIZE)
 
 
 def compress(data, sync_size=MAX_MEMBER_SIZE):
     out = io.BytesIO()
-    writer = IdZipFile(mode='w', fileobj=out, sync_size=sync_size)
+    writer = IdzipFile(mode='w', fileobj=out, sync_size=sync_size)
     writer.write(data)
     return out.getvalue()
 
 
 def decompress(data):
     in_ = io.BytesIO(data)
-    return IdZipFile(fileobj=in_).read()
+    return IdzipFile(fileobj=in_).read()
 
 
 class IdzipFile(object):
@@ -51,7 +50,7 @@ class IdzipFile(object):
         return GzipFile(filename, mode=mode, fileobj=fileobj)
 
     def _make_writer(self, filespec, sync_size):
-        return IdZipWriter(filespec, sync_size=sync_size)
+        return IdzipWriter(filespec, sync_size=sync_size)
 
     @property
     def name(self):
@@ -76,26 +75,27 @@ class IdzipFile(object):
     def _check_can_read(self):
         if "r" not in self.mode:
             raise OSError(errno.EBADF, "Cannot read from a write-only file")
-        if self.closed():
+        if self.closed:
             raise OSError(errno.EBADF, "Cannot read from a closed file")
 
     def _check_can_write(self):
         if not (set("wax") & set(self.mode)):
             raise OSError(errno.EBADF, "Cannot write to a read-only file")
-        if self.closed():
+        if self.closed:
             raise OSError(errno.EBADF, "Cannot write to a closed file")
 
     def readable(self):
-        return self._impl.stream.readable()
+        return self._impl.readable()
 
     def writable(self):
-        return self._impl.stream.writable()
+        return self._impl.writable()
 
+    @property
     def closed(self):
-        return self._impl.stream.closed()
+        return self._impl.closed
 
     def seekable(self):
-        return self._impl.stream.seekable()
+        return self._impl.seekable()
 
     def seek(self, offset, whence=io.SEEK_SET):
         return self._impl.seek(offset, whence)

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -70,6 +70,9 @@ class IdzipFile(object):
         self._check_can_read()
         return self._impl.read(size)
 
+    def tell(self):
+        return self._impl.tell()
+
     def _check_can_read(self):
         if "r" not in self.mode:
             raise OSError(errno.EBADF, "Cannot read from a write-only file")

--- a/idzip/api.py
+++ b/idzip/api.py
@@ -63,13 +63,11 @@ class IdzipFile(object):
         return self._impl.flush()
 
     def write(self, b):
-        if "r" in self.mode:
-            raise OSError(errno.EBADF, "Cannot write to a read-only file")
+        self._check_can_write()
         self._impl.write(b)
 
     def read(self, size=-1):
-        if "r" not in self.mode:
-            raise OSError(errno.EBADF, "Cannot read from a write-only file")
+        self._check_can_read()
         return self._impl.read(size)
 
     def _check_can_read(self):

--- a/idzip/compressor.py
+++ b/idzip/compressor.py
@@ -16,6 +16,8 @@ import struct
 from io import BytesIO, UnsupportedOperation
 from os import path, SEEK_END, SEEK_SET
 
+from ._stream import _CompressedStreamWrapperMixin
+
 # The chunk length used by dictzip.
 CHUNK_LENGTH = 58315
 
@@ -229,7 +231,7 @@ def _write32(output, value):
     output.write(struct.pack("<I", value & 0xffffffff))
 
 
-class IdzipWriter(object):
+class IdzipWriter(_CompressedStreamWrapperMixin):
     FILE_EXTENSION = 'dz'
     enforce_extension = True
 

--- a/idzip/compressor.py
+++ b/idzip/compressor.py
@@ -13,6 +13,9 @@ http://code.google.com/p/idzip/
 import zlib
 import struct
 
+from io import BytesIO
+from os import path, SEEK_END
+
 # The chunk length used by dictzip.
 CHUNK_LENGTH = 58315
 
@@ -27,7 +30,7 @@ COMPRESSION_LEVEL = zlib.Z_BEST_COMPRESSION
 # Gzip header flags from RFC 1952.
 GZIP_DEFLATE_ID = b"\x1f\x8b\x08"
 FTEXT, FHCRC, FEXTRA, FNAME, FCOMMENT = 1, 2, 4, 8, 16
-FRESERVED = 0xff - (FTEXT|FHCRC|FEXTRA|FNAME|FCOMMENT)
+FRESERVED = 0xff - (FTEXT | FHCRC | FEXTRA | FNAME | FCOMMENT)
 OS_CODE_UNIX = 3
 
 
@@ -48,10 +51,13 @@ def compress(input, in_size, output, basename=None, mtime=0):
         in_size -= member_size
         if in_size == 0:
             return
+
+
 def compress_member(input, in_size, output, basename, mtime):
     """ Make the 'private' function public for the writer class
     """
     return _compress_member(input, in_size, output, basename, mtime)
+
 
 def _compress_member(input, in_size, output, basename, mtime):
     """A gzip member contains:
@@ -81,7 +87,7 @@ def _compress_data(input, in_size, output):
     zlengths = []
     crcval = zlib.crc32(b"")
     compobj = zlib.compressobj(COMPRESSION_LEVEL, zlib.DEFLATED,
-            -zlib.MAX_WBITS)
+                               -zlib.MAX_WBITS)
 
     need = in_size
     while need > 0:
@@ -195,8 +201,8 @@ def _write_extra_field(output, in_size):
     if in_size % CHUNK_LENGTH != 0:
         num_chunks += 1
 
-    field_length = 3*2 + 2 * num_chunks
-    extra_length = 2*2 + field_length
+    field_length = 3 * 2 + 2 * num_chunks
+    extra_length = 2 * 2 + field_length
     assert extra_length <= 0xffff
     _write16(output, extra_length)  # XLEN
 
@@ -216,10 +222,218 @@ def _write16(output, value):
     """
     output.write(struct.pack("<H", value & 0xffff))
 
+
 def _write32(output, value):
     """Writes only the lowest 4 bytes from the given number.
     """
     output.write(struct.pack("<I", value & 0xffffffff))
 
 
+class IdZipWriter(object):
+    def __init__(self, output, sync_size=MAX_MEMBER_SIZE, mtime=0):
 
+        if isinstance(output, basestring):
+            self.output = open(output, "wb")
+        else:
+            self.output = output  # hopefully a file like object
+            self.output.seek(0)  # throw exception now if this isnt a file like obj
+        self.input_buffer = BytesIO()
+        try:
+            name = path.abspath(self.output.name)
+            basename = path.basename(name)
+            self.name = name
+            self.basename = basename
+        except AttributeError:
+            self.name = self.basename = ""
+        self.pos = 0
+        self.sync_size = sync_size
+        self.mtime = mtime
+        self.compressobj = zlib.compressobj(
+            COMPRESSION_LEVEL, zlib.DEFLATED,
+            -zlib.MAX_WBITS)
+        self.version = 1
+
+    def write(self, b):
+        start_pos = self.pos
+        self.input_buffer.write(b)
+        self.pos += len(b)
+        curpos = self.input_buffer.tell()
+        self.input_buffer.seek(0, SEEK_END)
+        buffer_len = self.input_buffer.tell()
+        self.input_buffer.seek(curpos)
+        if buffer_len > self.sync_size:
+            self.sync()
+            self.input_buffer = BytesIO()
+        return start_pos, len(b)
+
+    def sync(self):
+        self.compress_member()
+        self.input_buffer.truncate(0)
+        return self.output.tell()
+
+    def tell(self):
+        return self.pos
+
+    def flush(self):
+        self.sync()
+        return self.output.flush()
+
+    def close(self):
+        self.sync()
+        return self.output.close()
+
+    def compress_member(self):
+        """A gzip member contains:
+        1) The header.
+        2) The compressed data.
+        """
+        self.input_buffer.seek(0, SEEK_END)
+        member_size = self.input_buffer.tell()
+        self.input_buffer.seek(0)
+        zlengths_pos = self._prepare_header(member_size)
+        zlengths = self._compress_data(member_size)
+
+        # Writes the lengths of compressed chunks to the header.
+        end_pos = self.output.tell()
+        self.output.seek(zlengths_pos)
+        for zlen in zlengths:
+            _write16(self.output, zlen)
+
+        self.output.seek(end_pos)
+
+    def _prepare_header(self, in_size):
+        """Writes a prepared gzip header to the output.
+        The gzip header is defined in RFC 1952.
+
+        The gzip header starts with:
+        +---+---+---+---+---+---+---+---+---+---+
+        |x1f|x8b|x08|FLG|     MTIME     |XFL|OS |
+        +---+---+---+---+---+---+---+---+---+---+
+        where:
+        FLG ... flags. FEXTRA|FNAME is used by idzip.
+        MTIME ... the modification time of the original file or 0.
+        XFL ... extra flags about the compression.
+        OS ... operating system used for the compression.
+
+        The next header sections are:
+        1) Extra field, if the FEXTRA flag is set.
+           Its format is described in _write_extra_field().
+        2) The original file name, if the FNAME flag is set.
+           The file name string is zero-terminated.
+        """
+        self.output.write(GZIP_DEFLATE_ID)
+        flags = FEXTRA
+        if self.basename:
+            flags |= FNAME
+        self.output.write(bytearray([flags]))
+
+        # The mtime will be undefined if it does not fit.
+        if self.mtime > 0xffffffff:
+            mtime = 0
+        else:
+            mtime = self.mtime
+        _write32(self.output, mtime)
+
+        deflate_flags = b"\0"
+        if COMPRESSION_LEVEL == zlib.Z_BEST_COMPRESSION:
+            deflate_flags = b"\x02"  # slowest compression algorithm
+        self.output.write(deflate_flags)
+        self.output.write(bytearray([OS_CODE_UNIX]))
+
+        zlengths_pos = self._write_extra_field(in_size)
+        if self.basename:
+            self.output.write(self.basename + b'\0')  # original basename
+
+        return zlengths_pos
+
+    def _write_extra_field(self, in_size):
+        """Writes the dictzip extra field.
+        It will be initiated with zeros on the place of
+        the lengths of compressed chunks.
+
+        The gzip extra field is present when the FEXTRA flag is set.
+        RFC 1952 defines the used bytes:
+        +---+---+================================+
+        | XLEN  | XLEN bytes of "extra field" ...|
+        +---+---+================================+
+
+        Idzip adds only one subfield:
+        +---+---+---+---+===============================+
+        |'R'|'A'|  LEN  | LEN bytes of subfield data ...|
+        +---+---+---+---+===============================+
+
+        The subfield ID "RA" stands for Random Access.
+        That subfield ID signalizes the dictzip gzip extension.
+        The dictzip stores the length of uncompressed chunks
+        and the lengths of compressed chunks to the gzip header:
+        +---+---+---+---+---+---+==============================================+
+        | VER=1 | CHLEN | CHCNT | CHCNT 2-byte lengths of compressed chunks ...|
+        +---+---+---+---+---+---+==============================================+
+
+        Two bytes are used to store a length of a compressed chunk.
+        So the length of a compressed chunk has to be max 0xfffff.
+        That puts a restriction on the CHLEN -- the length of
+        uncompressed chunks. Dictzip uses CHLEN=58315.
+
+        Only a fixed number of chunk lengths will fit to the gzip header.
+        That limits the max file size of a dictzip file.
+        Idzip does not have that limitation. It starts a new gzip member if needed.
+        The new member would be also a valid dictzip file.
+        """
+        num_chunks = in_size // CHUNK_LENGTH
+        if in_size % CHUNK_LENGTH != 0:
+            num_chunks += 1
+
+        field_length = 3 * 2 + 2 * num_chunks
+        extra_length = 2 * 2 + field_length
+        assert extra_length <= 0xffff
+        _write16(self.output, extra_length)  # XLEN
+
+        # Dictzip extra field (Random Access)
+        self.output.write(b"RA")
+        _write16(self.output, field_length)
+        _write16(self.output, self.version)  # version
+        _write16(self.output, CHUNK_LENGTH)
+        _write16(self.output, num_chunks)
+        zlengths_pos = self.output.tell()
+        self.output.write(b"\0\0" * num_chunks)
+        return zlengths_pos
+
+    def _compress_data(self, in_size):
+        """Compresses the given number of input bytes to the output.
+        The output consists of:
+        1) The compressed data.
+        2) 4 bytes of CRC.
+        3) 4 bytes of file size.
+        """
+        assert in_size <= 0xffffffff
+        zlengths = []
+        crcval = zlib.crc32(b"")
+
+        need = in_size
+        while need > 0:
+            read_size = min(need, CHUNK_LENGTH)
+            chunk = self.input_buffer.read(read_size)
+            if len(chunk) != read_size:
+                raise IOError("Need %s bytes, got %s" % (read_size, len(chunk)))
+
+            need -= len(chunk)
+            crcval = zlib.crc32(chunk, crcval)
+            zlen = self._compress_chunk(chunk)
+            zlengths.append(zlen)
+
+        # An empty block with BFINAL=1 flag ends the zlib data stream.
+        self.output.write(self.compressobj.flush(zlib.Z_FINISH))
+        _write32(self.output, crcval)
+        _write32(self.output, in_size)
+        return zlengths
+
+    def _compress_chunk(self, chunk):
+        data = self.compressobj.compress(chunk)
+        zlen = len(data)
+        self.output.write(data)
+
+        data = self.compressobj.flush(zlib.Z_FULL_FLUSH)
+        zlen += len(data)
+        self.output.write(data)
+        return zlen

--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -3,14 +3,15 @@ import os
 import struct
 import zlib
 import itertools
-from io import BytesIO
+from io import BytesIO, open
 
 from idzip import compressor, caching
+from idzip._stream import _CompressedStreamWrapperMixin
 
 GZIP_CRC32_LEN = 4
 
 
-class IdzipReader(object):
+class IdzipReader(_CompressedStreamWrapperMixin):
     def __init__(self, filename=None, fileobj=None):
         if filename is None:
             if fileobj:
@@ -37,7 +38,7 @@ class IdzipReader(object):
 
     @property
     def stream(self):
-        return self.output
+        return self._fileobj
 
     def _read_member_header(self):
         """Extends self._members and self._chunks

--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -135,9 +135,6 @@ class IdzipReader(IOStreamWrapperMixin):
             self._fileobj.close()
         self._cache = None
 
-    def fileno(self):
-        return self.stream.fileno()
-
     def _index_pos(self, pos):
         """Returns (chunk_index, remainder) index
         for the given position in uncompressed data.

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -109,7 +109,7 @@ def _eq_zformat(expected, output, mtime=0, expected_basename=None, in_size=None)
 
     # FEXTRA header
     info_len = 10
-    xlen_bytes = expected.read(2)
+    xlen_bytes = bytearray(expected.read(2))
     asserting.eq_bytes(xlen_bytes, output.read(2))
 
     xlen = xlen_bytes[0] & 0xff + 256 * (xlen_bytes[1] & 0xff)
@@ -159,4 +159,3 @@ def _eq_zstream(expected, produced):
     got = deobj.decompress(produced.read())
     produced.seek(-len(deobj.unused_data), os.SEEK_CUR)
     asserting.eq_bytes(expected_data, got)
-

--- a/test/test_high_level_api.py
+++ b/test/test_high_level_api.py
@@ -53,5 +53,31 @@ def test_idzip_file_api():
     os.remove(gzfile)
 
 
+def test_large_write():
+
+    # find the largest fraction of MAX_MEMBER_SIZE that can
+    # be allocated
+    data = b''
+    for d in range(1, 1000):
+        try:
+            data = b"a" * (api.MAX_MEMBER_SIZE // d)
+            break
+        except MemoryError:
+            continue
+    if data == b'':
+        # no test could be performed
+        return
+
+    dfd, dzfile = tempfile.mkstemp(suffix='.dz')
+    with IdzipFile(dzfile, 'wb') as writer:
+        writer.write(data)
+
+    assert writer.closed
+
+    os.close(dfd)
+    os.remove(dzfile)
+
+
 if __name__ == '__main__':
     test_idzip_file_api()
+    test_large_write()

--- a/test/test_high_level_api.py
+++ b/test/test_high_level_api.py
@@ -15,34 +15,40 @@ except NameError:
 def random_string(size):
     size = int(size)
     letters = [random.choice(string.ascii_letters) for i in range(size)]
-    return ''.join(letters)
+    return ''.join(letters).encode("utf8")
+
+
+IdzipFile = api.IdzipFile
 
 
 def test_idzip_file_api():
     data = random_string(5e6)
 
-    _, dzfile = tempfile.mkstemp(suffix='.dz')
-    _, gzfile = tempfile.mkstemp(suffix='.gz')
-
-    with api.IdzipFile(dzfile, 'wb') as writer:
+    dfd, dzfile = tempfile.mkstemp(suffix='.dz')
+    with IdzipFile(dzfile, 'wb') as writer:
         writer.write(data)
 
     assert writer.closed
 
-    with api.IdzipFile(dzfile, 'rb') as reader:
+    with IdzipFile(dzfile, 'rb') as reader:
         decoded = reader.read()
 
     assert reader.closed
     assert data == decoded
+
+    gfd, gzfile = tempfile.mkstemp(suffix='.gz')
 
     with gzip.open(gzfile, 'wb') as writer:
         writer.write(data)
 
-    with api.IdzipFile(gzfile, 'rb') as reader:
+    with IdzipFile(gzfile, 'rb') as reader:
         decoded = reader.read()
 
     assert reader.closed
     assert data == decoded
+
+    os.close(gfd)
+    os.close(dfd)
     os.remove(dzfile)
     os.remove(gzfile)
 

--- a/test/test_high_level_api.py
+++ b/test/test_high_level_api.py
@@ -1,0 +1,51 @@
+import random
+import string
+import gzip
+import os
+import tempfile
+
+from idzip import api
+
+try:
+    range = xrange
+except NameError:
+    pass
+
+
+def random_string(size):
+    size = int(size)
+    letters = [random.choice(string.ascii_letters) for i in range(size)]
+    return ''.join(letters)
+
+
+def test_idzip_file_api():
+    data = random_string(5e6)
+
+    _, dzfile = tempfile.mkstemp(suffix='.dz')
+    _, gzfile = tempfile.mkstemp(suffix='.gz')
+
+    with api.IdzipFile(dzfile, 'wb') as writer:
+        writer.write(data)
+
+    assert writer.closed
+
+    with api.IdzipFile(dzfile, 'rb') as reader:
+        decoded = reader.read()
+
+    assert reader.closed
+    assert data == decoded
+
+    with gzip.open(gzfile, 'wb') as writer:
+        writer.write(data)
+
+    with api.IdzipFile(gzfile, 'rb') as reader:
+        decoded = reader.read()
+
+    assert reader.closed
+    assert data == decoded
+    os.remove(dzfile)
+    os.remove(gzfile)
+
+
+if __name__ == '__main__':
+    test_idzip_file_api()


### PR DESCRIPTION
I wanted to be able to use `IdzipFile` as a drop-in replacement for GzipFile in external library code for both reading and writing, but the current `IdzipFile` implementation is only for reading, requiring a separate type for writing, and refused to open plain gzipped files.

I've refactored `idzip.IdzipFile` to support both reading and writing, as well as providing the full file-like API that Python's standard library compressed file IO modules provide. The only difference between the current API surface and Py3's `gzip.GzipFile` is that compressed files cannot be opened in text mode. Other changes include support for using `IdzipFile` to read plain gzipped files by automatically proxying reading to a GzipFile instance when the RA access key is missing from the header. 

I think I've managed to preserve all previous importable names behaving the same way they used to when imported from their original locations.