### PR TITLE
Fix bug in api.compress() - flush not called

### DIFF
--- a/idzip/api.py
+++ b/idzip/api.py
@@ -14,6 +14,7 @@ def compress(data, sync_size=MAX_MEMBER_SIZE):
     out = io.BytesIO()
     writer = IdzipFile(mode='w', fileobj=out, sync_size=sync_size)
     writer.write(data)
+    writer.flush()
     return out.getvalue()
 
 


### PR DESCRIPTION
The compress() is broken, as it doesn't call flush before exit, so the data isn't written.