### PR TITLE
seek() should return the new absolute position

### DIFF
--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -237,6 +237,7 @@ class IdzipReader(IOStreamWrapperMixin):
         if new_pos < 0:
             raise ValueError("Invalid pos: %r" % new_pos)
         self._pos = new_pos
+        return new_pos
 
     def __repr__(self):
         return "<idzip %s file %r at %s>" % (


### PR DESCRIPTION
To be compatible with the standard Python file object API, the `seek` method should return the new absolute position as an integer.

For example:

```
>>> open('/tmp/x.dz', 'wb').write(b'\x1f\x8b\x08\x0c\x16\x9e\xa3c\x02\x03\x0c\0RA\x08\0\x01\0\xcb\xe3\x01\0\x0b\0x\0JLLL\xe4\x02\0\0\0\xff\xff\x03\0i+\xcc4\x05\0\0\0')
47
>>> open('/tmp/x.dz').seek(1)
1
>>> import gzip
>>> gzip.open('/tmp/x.dz').seek(1)
1
>>> import idzip
>>> idzip.open('/tmp/x.dz').seek(1)
```
