### PR TITLE
Support SEEK_END

### DIFF
--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -230,7 +230,14 @@ class IdzipReader(IOStreamWrapperMixin):
         elif whence == os.SEEK_CUR:
             new_pos = self._pos + offset
         elif whence == os.SEEK_END:
-            raise ValueError("Seek from the end not supported")
+            # Parse every member until we find the last one.
+            while True:
+                try:
+                    self._parse_next_member()
+                except EOFError:
+                    break
+            end = self._members[-1].start_pos + self._members[-1].isize
+            new_pos = end + offset
         else:
             raise ValueError("Unknown whence: %r" % whence)
 


### PR DESCRIPTION
It's useful to be able to determine the end of the file by calling `f.seek(0, os.SEEK_END)`.

I'm not very familiar with the code and I'm not very familiar with the details of the idzip format, but I *think* this should work.  Careful testing and review would be appreciated. :)

Note that every call to `seek(0, os.SEEK_END)` will attempt to read more data from the file (unlike `SEEK_SET` and `SEEK_CUR`, which only change `_pos` and don't perform any I/O at all.)  This feels consistent with normal Python behavior and the way `seek` currently works, though many applications will want to avoid the additional I/O by caching the end position after the first call.
