### PR TITLE
Handling file position when EOF is reached

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,5 @@ jobs:
         cd test
         pytest -l -s -v test_high_level_api.py --cov-report term
         cd ..
-        rm -f test/data/large.txt.dz test/data/sample.txt.dz
+        rm test/data/large.txt.dz test/data/sample.txt.dz
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,4 +26,12 @@ jobs:
     - name: Test Testable Components
       run: |
         # All other tests depend upon fixture data not stored with the repository
-        cd test && pytest -l -s -v test_high_level_api.py --cov-report term
+        echo "generating a data file sufficient to extend past 1 member"
+        curl -o test/data/sample.txt  http://textfiles.com/stories/bureau.txt
+        seq 30000 | xargs -P1 -n1 -I@ cat test/data/sample.txt >> test/data/large.txt
+        python idzip/command.py test/data/large.txt
+        cd test
+        pytest -l -s -v test_high_level_api.py --cov-report term
+        cd ..
+        rm -rf test/data/large.txt.dz test/data/sample.txt.dz
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,5 +32,6 @@ jobs:
         python idzip/command.py test/data/large.txt
         cd test
         pytest -l -s -v test_high_level_api.py --cov-report term
+        cd ..
         pytest -l -s -v test_seek_read_behavior.py --cov-report term
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,5 @@ jobs:
         cd test
         pytest -l -s -v test_high_level_api.py --cov-report term
         cd ..
-        rm -rf test/data/large.txt.dz test/data/sample.txt.dz
+        rm -f test/data/large.txt.dz test/data/sample.txt.dz
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,5 @@ jobs:
         cd test
         pytest -l -s -v test_high_level_api.py --cov-report term
         cd ..
-        pytest -l -s -v test_seek_read_behavior.py --cov-report term
+        pytest -l -s -v test/test_seek_read_behavior.py --cov-report term
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,5 @@ jobs:
         python idzip/command.py test/data/large.txt
         cd test
         pytest -l -s -v test_high_level_api.py --cov-report term
-        cd ..
-        rm test/data/large.txt.dz test/data/sample.txt.dz
+        pytest -l -s -v test_seek_read_behavior.py --cov-report term
 

--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -102,12 +102,13 @@ class IdzipReader(IOStreamWrapperMixin):
         except EOFError:
             # PR#16/18 - support identifying EOF
             #         use a read() as a sync from desired position to actual position
-            #         read(0) can be used aws a
+            #         read(0) can be used as a synchronization call
             dec_eof_position = self._members[-1].start_pos + self._members[-1].isize
             self._pos = dec_eof_position
             if prefixed_buffer:
                 # subtracting the data in the EOF Case so the normal path will add it back
                 # before the function return to avoid changing the path
+                # adding up lengths rather than concatenating here to avoid creating new buffers
                 self._pos -= sum([len(x) for x in prefixed_buffer])
         prefixed_buffer = b"".join(prefixed_buffer)
         result = prefixed_buffer[prefix_size:]

--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -1,6 +1,6 @@
 
 import os
-import sys
+from math import inf
 import struct
 import zlib
 import itertools
@@ -241,7 +241,8 @@ class IdzipReader(IOStreamWrapperMixin):
         elif whence == os.SEEK_END:
             if offset != 0:
                 raise ValueError("Seek from the end not supported unless offset is set to 0")
-            new_pos = sys.maxsize
+            member = self._select_member(inf)
+            new_pos = member.start_pos + member.isize
         else:
             raise ValueError("Unknown whence: %r" % whence)
 

--- a/idzip/decompressor.py
+++ b/idzip/decompressor.py
@@ -239,10 +239,8 @@ class IdzipReader(IOStreamWrapperMixin):
         elif whence == os.SEEK_CUR:
             new_pos = self._pos + offset
         elif whence == os.SEEK_END:
-            if offset != 0:
-                raise ValueError("Seek from the end not supported unless offset is set to 0")
             member = self._select_member(inf)
-            new_pos = member.start_pos + member.isize
+            new_pos = member.start_pos + member.isize + offset
         else:
             raise ValueError("Unknown whence: %r" % whence)
 

--- a/test/test_seek_read_behavior.py
+++ b/test/test_seek_read_behavior.py
@@ -1,11 +1,45 @@
 import idzip
+import gzip
 import io
+from time import time
 
-
-def test_seeking():
+def test_seeking(report_time=False):
     f = idzip.open("test/data/large.txt.dz")
-    f.seek(0, io.SEEK_END)
-    initial = f.tell()
+    g = gzip.open("test/data/large.txt.dz")
+    f_s_s = time()  # file_seek_start time
+    f_pos = f.seek(0, io.SEEK_END)
+    f_s_e = time() # file_seek_end time
+    if report_time:
+        print(f"idzip seek time: {f_s_e - f_s_s}")
+    g_s_s = time()
+    g_pos = g.seek(0, io.SEEK_END)
+    g_s_e = time()
+    if report_time:
+        print(f"gzip seek time: {g_s_e - g_s_s}")
+    # gzip will find the exact EOF position during the seek
+    # idzip can find the exact EOF position during a read call
+    assert g_pos != f_pos
+
+    f_r_s = time()  # file_read_start
     f.read(0)
-    final = f.tell()
-    assert initial != final
+    f_r_e = time()  # file_read_end
+    if report_time:
+        print(f"idzip read time: {f_r_e - f_r_s}")
+    g_r_s = time()
+    g.read(0)
+    g_r_e = time()
+    if report_time:
+        print(f"gzip read time: {g_r_e - g_r_s}")
+        print(f"seek+read END time comparison: {((f_r_e - f_r_s) / (g_s_e - g_s_s)) * 100}%")
+
+    # the file position should now be synchronized
+    f_pos = f.tell()
+    g_pos = g.tell()
+    if report_time:
+        print(f"idzip END: {f_pos}")
+        print(f"idzip END: {g_pos}")
+    assert f_pos == g_pos
+
+
+if __name__ == "__main__":
+    test_seeking(report_time=True)

--- a/test/test_seek_read_behavior.py
+++ b/test/test_seek_read_behavior.py
@@ -1,0 +1,11 @@
+import idzip
+import io
+
+
+def test_seeking():
+    f = idzip.open("test/data/large.txt.dz")
+    f.seek(0, io.SEEK_END)
+    initial = f.tell()
+    f.read(0)
+    final = f.tell()
+    assert initial != final

--- a/test/test_seek_read_behavior.py
+++ b/test/test_seek_read_behavior.py
@@ -37,7 +37,7 @@ def test_seeking(report_time=False):
     g_pos = g.tell()
     if report_time:
         print(f"idzip END: {f_pos}")
-        print(f"idzip END: {g_pos}")
+        print(f"gzip END:  {g_pos}")
     assert f_pos == g_pos
 
 

--- a/test/test_seek_read_behavior.py
+++ b/test/test_seek_read_behavior.py
@@ -17,8 +17,8 @@ def test_seeking(report_time=False):
     if report_time:
         print(f"gzip seek time: {g_s_e - g_s_s}")
     # gzip will find the exact EOF position during the seek
-    # idzip can find the exact EOF position during a read call
-    assert g_pos != f_pos
+    # idzip can find the exact EOF position during only if using SEEK_END
+    assert g_pos == f_pos
 
     f_r_s = time()  # file_read_start
     f.read(0)
@@ -30,7 +30,6 @@ def test_seeking(report_time=False):
     g_r_e = time()
     if report_time:
         print(f"gzip read time: {g_r_e - g_r_s}")
-        print(f"seek+read END time comparison: {((f_r_e - f_r_s) / (g_s_e - g_s_s)) * 100}%")
 
     # the file position should now be synchronized
     f_pos = f.tell()


### PR DESCRIPTION
decompressed reported position is not accurate when cursor hits the end of the compressed file.

This is impacting a workaround for #16 