### PR TITLE
nixpkgs: fix bin folder collisions

### DIFF
--- a/bin/idzip
+++ b/bin/idzip
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec python -m idzip.command "$@"

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,4 @@ setup(
                        'Programming Language :: Python :: 2',
                        'Programming Language :: Python :: 3',
                    ],
-    scripts=['bin/idzip']
 )


### PR DESCRIPTION
The nixpkgs build tools create a bin folder during the build, which causes a conflict.
I don't know about .spec files, could you help with this? 
https://github.com/bauman/python-idzip/blob/2a26db03b79105c709f2fa81787bcf588f5a5419/python-idzip.spec#L12


https://github.com/NixOS/nixpkgs/pull/289044